### PR TITLE
Fix: templates render invalid yaml

### DIFF
--- a/code/charts/sustainable-saas/templates/hana_deployer_job.yaml
+++ b/code/charts/sustainable-saas/templates/hana_deployer_job.yaml
@@ -23,7 +23,7 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       restartPolicy: Never
-      {{- include "cap.imagePullSecrets" $ | nindent 6 -}}
+      {{- include "cap.imagePullSecrets" $ | nindent 6 }}
       volumes:
         {{- include "cap.sapcp.bindingsVolumes" $ | nindent 10 }}
       containers:

--- a/code/charts/sustainable-saas/templates/html5_apps_deployer_job.yaml
+++ b/code/charts/sustainable-saas/templates/html5_apps_deployer_job.yaml
@@ -25,7 +25,7 @@ spec:
         {{- include "cap.labels" $ | nindent 8 }}
         sidecar.istio.io/inject: "false"
     spec:
-      {{- include "cap.imagePullSecrets" $ | nindent 6 -}}
+      {{- include "cap.imagePullSecrets" $ | nindent 6 }}
       restartPolicy: Never
       volumes:
         {{- include "cap.sapcp.bindingsVolumes" $ | nindent 10 }}


### PR DESCRIPTION
In case 'global.imagePullSecret.name' is set, those templates were missing a newline in the yaml output.